### PR TITLE
New IDS-Framework Version 4.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versions before 4.0.0 are available on [GitLab](https://gitlab.cc-asp.fraunhofer
 ### Fixed
 ### Security 
 
+## [4.0.4] - 2021-02-04
+### Changed
+- Sending an automatic ErrorResponse/RejectionsMessage can now include the message-ID of the rejected message, if it was available
+
 ## [4.0.3] - 2021-01-29
 ### Fixed
 - ClientProvider: override read timeout if given

--- a/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/handling/MessageDispatcher.java
+++ b/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/handling/MessageDispatcher.java
@@ -105,7 +105,8 @@ public class MessageDispatcher {
                 if (!result.isSuccess()) {
                     logger.debug("A preDispatchingFilter failed!");
                     logger.error(result.getMessage(), result.getError());
-                    return ErrorResponse.withDefaultHeader(RejectionReason.MALFORMED_MESSAGE, result.getMessage(), connectorId, modelVersion);
+
+                    return ErrorResponse.withDefaultHeader(RejectionReason.MALFORMED_MESSAGE, result.getMessage(), connectorId, modelVersion, header.getId());
                 }
             } catch (Exception e) {
                 logger.debug("A preDispatchingFilter threw an exception!");
@@ -126,12 +127,14 @@ public class MessageDispatcher {
                 return handler.handleMessage(header, new MessagePayloadImpl(payload, objectMapper));
             } catch (MessageHandlingException e) {
                 logger.debug("The message handler threw an exception!");
-                return ErrorResponse.withDefaultHeader(RejectionReason.INTERNAL_RECIPIENT_ERROR, "Error while handling the request!", connectorId, modelVersion);
+
+                return ErrorResponse.withDefaultHeader(RejectionReason.INTERNAL_RECIPIENT_ERROR,"Error while handling the request!", connectorId, modelVersion, header.getId());
             }
         } else {
             logger.debug(String.format("No message handler exists for %s", header.getClass()));
+
             //If no handler for the type exists, the message type isn't supported
-            return ErrorResponse.withDefaultHeader(RejectionReason.MESSAGE_TYPE_NOT_SUPPORTED, "No handler for provided message type was found!", connectorId, modelVersion);
+            return ErrorResponse.withDefaultHeader(RejectionReason.MESSAGE_TYPE_NOT_SUPPORTED, "No handler for provided message type was found!", connectorId, modelVersion, header.getId());
         }
     }
 

--- a/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/model/responses/ErrorResponse.java
+++ b/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/model/responses/ErrorResponse.java
@@ -50,12 +50,17 @@ public class ErrorResponse implements MessageResponse {
      * @param errorMessage detailed error description
      * @param connectorId id of the current connector
      * @param modelVersion infomodelversion of the current connector
+     * @param messageId id of the message being rejected (from message-header)
      * @return an instance of ErrorResponse with the given parameters
      */
-    public static ErrorResponse withDefaultHeader(final RejectionReason rejectionReason, final String errorMessage, final URI connectorId, final String modelVersion){
+    public static ErrorResponse withDefaultHeader(final RejectionReason rejectionReason, final String errorMessage, final URI connectorId, final String modelVersion, URI messageId){
+        if(messageId == null) {
+            messageId = URI.create("https://INVALID");
+        }
+
         var rejectionMessage = new RejectionMessageBuilder()
                 ._securityToken_(new DynamicAttributeTokenBuilder()._tokenFormat_(TokenFormat.JWT)._tokenValue_("rejected!").build())
-                ._correlationMessage_(URI.create("https://INVALID"))
+                ._correlationMessage_(messageId)
                 ._senderAgent_(connectorId)
                 ._issuerConnector_(connectorId)
                 ._modelVersion_(modelVersion)
@@ -63,6 +68,19 @@ public class ErrorResponse implements MessageResponse {
                 ._issued_(IDSUtils.getGregorianNow())
                 .build();
         return new ErrorResponse(rejectionMessage, errorMessage);
+    }
+
+    /**
+     * Create an ErrorResponse with Default RejectionMessage as header (only RejectionReason has to be Provided)
+     *
+     * @param rejectionReason RejectionReason (why the message was rejected)
+     * @param errorMessage detailed error description
+     * @param connectorId id of the current connector
+     * @param modelVersion infomodelversion of the current connector
+     * @return an instance of ErrorResponse with the given parameters
+     */
+    public static ErrorResponse withDefaultHeader(final RejectionReason rejectionReason, final String errorMessage, final URI connectorId, final String modelVersion){
+        return withDefaultHeader(rejectionReason, errorMessage, connectorId, modelVersion, null);
     }
 
     /**{@inheritDoc}*/

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     </modules>
 
     <properties>
-        <revision>4.0.3</revision>
+        <revision>4.0.4</revision>
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
- Sending an automatic ErrorResponse/RejectionMessage can now include the message-ID of the rejected message, if it was available