### PR TITLE
Forward received RejectionMessages to Connector-Developer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versions before 4.0.0 are available on [GitLab](https://gitlab.cc-asp.fraunhofer
 ### Fixed
 ### Security 
 
+## [4.0.5] - 2021-02-11
+### Changed
+- Received RejectionMessages are now passed to the connector-developer, regardless of the status of the DAT within the received RejectionMessage
+
 ## [4.0.4] - 2021-02-04
 ### Changed
 - Sending an automatic ErrorResponse/RejectionsMessage can now include the message-ID of the rejected message, if it was available

--- a/base/src/main/java/de/fraunhofer/isst/ids/framework/daps/DapsValidator.java
+++ b/base/src/main/java/de/fraunhofer/isst/ids/framework/daps/DapsValidator.java
@@ -1,6 +1,7 @@
 package de.fraunhofer.isst.ids.framework.daps;
 
 import de.fraunhofer.iais.eis.Message;
+import de.fraunhofer.iais.eis.RejectionMessageImpl;
 import de.fraunhofer.iais.eis.ids.jsonld.Serializer;
 import de.fraunhofer.isst.ids.framework.util.MultipartStringParser;
 import io.jsonwebtoken.Claims;
@@ -58,6 +59,12 @@ public class DapsValidator {
      * @return true if DAT of Message is valid
      */
     public boolean checkDat(Message message) {
+        //Don't check DAT of RejectionMessages
+        if(message instanceof RejectionMessageImpl ) {
+            LOGGER.warn("RejectionMessage, skipping DAT check!");
+            return true;
+        }
+
         Jws<Claims> claims;
         try {
             claims = getClaims(message, keyProvider.providePublicKey());

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     </modules>
 
     <properties>
-        <revision>4.0.4</revision>
+        <revision>4.0.5</revision>
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
[BASE] #CHANGE 'function:DapsValidator'
<issue-11>
{Skip DAT check for RejectionMessages, so that they can be forwarded to a connector-developer handler}